### PR TITLE
CTestXML2HTML.py compatible with Python 2 and 3

### DIFF
--- a/cmake/ElementsProjectConfig.cmake
+++ b/cmake/ElementsProjectConfig.cmake
@@ -349,8 +349,7 @@ macro(elements_project project version)
 
   find_program(ctestxml2html_cmd CTestXML2HTML.py HINTS ${binary_paths})
   if(ctestxml2html_cmd)
-#    set(ctestxml2html_cmd ${PYTHON_EXECUTABLE} ${ctestxml2html_cmd})
-    set(ctestxml2html_cmd python ${ctestxml2html_cmd})
+    set(ctestxml2html_cmd ${PYTHON_EXECUTABLE} ${ctestxml2html_cmd})
   endif()
 
   mark_as_advanced(env_cmd merge_cmd versheader_cmd instheader_cmd versmodule_cmd instmodule_cmd

--- a/cmake/auxdir/test/HTMLTestReportSkel/index.html
+++ b/cmake/auxdir/test/HTMLTestReportSkel/index.html
@@ -2,7 +2,7 @@
 <!DOCTYPE HTML>
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
     <head>
-        <meta http-equiv="Content-Type" content="text/html"/>
+        <meta http-equiv="Content-Type" content="text/html;charset=utf-8"/>
         <title>Test Report</title>
         <link rel="stylesheet" type="text/css" href="css/jquery-ui-1.10.3.css"/>
         <link rel="stylesheet" type="text/css" href="css/style.css"/>

--- a/cmake/scripts/CTestXML2HTML.py
+++ b/cmake/scripts/CTestXML2HTML.py
@@ -1,5 +1,6 @@
-#!/usr/bin/env python
 # -*- coding:utf-8 -*-
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import os
 import sys
 import json
@@ -63,9 +64,6 @@ def formatMeasurementText(txt, escape=False, preformat=True):
     '''
     from xml.sax.saxutils import escape as escape_xml
     from codecs import encode
-    if hasattr(txt, 'decode'):
-        txt = txt.decode(errors='ignore')
-    txt = encode(txt, 'utf-8', 'xmlcharrefreplace')
     if escape:
         txt = escape_xml(txt)
     if preformat:
@@ -83,13 +81,13 @@ def dropCustomMeasurements(s):
     '<DartMeasurement ...></DartMeasurement>' tags) from the input string and
     return the new value.
     '''
-    pos = s.find(b'<DartMeasurement')
+    pos = s.find('<DartMeasurement')
     while pos >= 0:
-        end_pos = s.find(b'</DartMeasurement>', pos)
+        end_pos = s.find('</DartMeasurement>', pos)
         if end_pos < 0:
             break  # no end tag, better not to drop the section
         s = s[:pos] + s[end_pos + 18:]  # 18 is the size of the end tag
-        pos = s.find(b'<DartMeasurement')
+        pos = s.find('<DartMeasurement')
     return s
 
 
@@ -325,7 +323,7 @@ class TestOrganizer:
 
     def _addStatistics(self):  # ,groupContainer,fatherAdresses):
         """ add statistics to the html structure."""
-        for group in self._groups.iteritems():
+        for group in self._groups.items():
             if group[0] not in self.fieldToAvoidList:
                 self._addStatistic(group[1])
 
@@ -348,12 +346,12 @@ class TestOrganizer:
                 stats.clear()
                 stats.set("class", "statistics")
 
-        for stat in group["Statistics"].iteritems():
+        for stat in group["Statistics"].items():
             ET.SubElement(stats, "span", {
                           "class": stat[0]}).text = '  ' + stat[0] + ' = ' + str(stat[1])
 
         # process all the subgroups
-        for grp in group.iteritems():
+        for grp in group.items():
             if grp[0] not in self.fieldToAvoidList:
                 self._addStatistic(grp[1])
 
@@ -421,7 +419,7 @@ class TestOrganizer:
             @param depthMax: The maximum depth to search in. A negative value
                 correspond to no limit.
             """
-            iterator = master.getchildren()
+            iterator = list(master)
             if len(iterator) == 0 or depthMax == 0:
                 return None
             found = False
@@ -458,7 +456,7 @@ def get_cpuinfo():
         current = {}
         for l in open('/proc/cpuinfo'):
             try:
-                k, v = map(str.strip, l.split(':', 1))
+                k, v = map(lambda s: s.strip(), l.split(':', 1))
                 if k == 'processor':
                     current = {k: v}
                     cpuinfo.append(current)
@@ -784,6 +782,9 @@ def main():
                         text = VALUE_DECODE[value.attrib['encoding']](text)
                     if 'compression' in value.attrib:
                         text = VALUE_DECOMP[value.attrib['compression']](text)
+                    # In Python3 the methods in VALUE_DECOMP return a bytes object, which has to be decoded
+                    if hasattr(text, 'decode'):
+                        text = text.decode('utf-8')
                     text = dropCustomMeasurements(text)
                     text = formatMeasurementText(text, escape=True)
                     # no "Measurement" or no "Value" or no text
@@ -798,8 +799,8 @@ def main():
                             summary, x))
                     # encoding or compressions unknown, keep original text
                     text = formatMeasurementText(value=text, escape=True)
-                with open(os.path.join(testCaseDir, "stdout"), "w") as stdout:
-                    stdout.write(text)
+                with open(os.path.join(testCaseDir, "stdout"), "wb") as stdout:
+                    stdout.write(text.encode('utf-8'))
 
                 if "ctest" not in site.get("Generator"):
                     # write the other files


### PR DESCRIPTION
* Decode once at the beginning, decode when writing out, handle everything as an unicode string in the middle
* iteritems => items
* import futures

I have tested with Python 2.7 and Python 3.7 (manually at first, via PYTHON_EXPLICIT_VERSION for integration test)