### PR TITLE
Remove the FORCE for CMAKE_*_INSTALL_SUFFIX

### DIFF
--- a/cmake/ElementsLocations.cmake
+++ b/cmake/ElementsLocations.cmake
@@ -83,8 +83,8 @@ if(SQUEEZED_INSTALL)
   endif()
 endif()
 
-set(CMAKE_LIB_INSTALL_SUFFIX ${lib_install_suff} CACHE STRING "Suffix for the install directory of the libraries" FORCE)
-set(CMAKE_BIN_INSTALL_SUFFIX bin CACHE STRING "Suffix for the install directory of the binaries" FORCE)
+set(CMAKE_LIB_INSTALL_SUFFIX ${lib_install_suff} CACHE STRING "Suffix for the install directory of the libraries")
+set(CMAKE_BIN_INSTALL_SUFFIX bin CACHE STRING "Suffix for the install directory of the binaries")
 
 
 


### PR DESCRIPTION
Elements only uses lib64 for x86_64, but in Fedora we also have
aarch64, ppc64, and s390x. For packaging there, we need to be able to
override the destination.