### PR TITLE
Import FindGSL from CMake

### DIFF
--- a/cmake/modules/FindGSL.cmake
+++ b/cmake/modules/FindGSL.cmake
@@ -1,40 +1,173 @@
-# - Locate GSL library
-# Defines:
-#
-#  GSL_FOUND
-#  GSL_INCLUDE_DIR
-#  GSL_INCLUDE_DIRS (not cached)
-#  GSL_LIBRARY
-#  GSL_CBLAS_LIBRARY
-#  GSL_LIBRARIES (not cached)
+# Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+# file Copyright.txt or https://cmake.org/licensing for details.
 
+include(FindPackageHandleStandardArgs)
 
-if(NOT GSL_FOUND)
+#=============================================================================
+# If the user has provided ``GSL_ROOT_DIR``, use it!  Choose items found
+# at this location over system locations.
+if( EXISTS "$ENV{GSL_ROOT_DIR}" )
+  file( TO_CMAKE_PATH "$ENV{GSL_ROOT_DIR}" GSL_ROOT_DIR )
+  set( GSL_ROOT_DIR "${GSL_ROOT_DIR}" CACHE PATH "Prefix for GSL installation." )
+endif()
+if( NOT EXISTS "${GSL_ROOT_DIR}" )
+  set( GSL_USE_PKGCONFIG ON )
+endif()
 
-  find_path(GSL_INCLUDE_DIR gsl/gsl_version.h
-            HINTS ENV GSL_ROOT_DIR
-            PATH_SUFFIXES include)
+#=============================================================================
+# As a first try, use the PkgConfig module.  This will work on many
+# *NIX systems.  See :module:`findpkgconfig`
+# This will return ``GSL_INCLUDEDIR`` and ``GSL_LIBDIR`` used below.
+if( GSL_USE_PKGCONFIG )
+  find_package(PkgConfig)
+  pkg_check_modules( GSL QUIET gsl )
 
-  find_library(GSL_LIBRARY gsl
-               HINTS ENV GSL_ROOT_DIR
-               PATH_SUFFIXES lib)
+  if( EXISTS "${GSL_INCLUDEDIR}" )
+    get_filename_component( GSL_ROOT_DIR "${GSL_INCLUDEDIR}" DIRECTORY CACHE)
+  endif()
+endif()
 
-  find_library(GSL_CBLAS_LIBRARY gslcblas
-               HINTS ENV GSL_ROOT_DIR
-               PATH_SUFFIXES lib)
+#=============================================================================
+# Set GSL_INCLUDE_DIRS and GSL_LIBRARIES. If we skipped the PkgConfig step, try
+# to find the libraries at $GSL_ROOT_DIR (if provided) or in standard system
+# locations.  These find_library and find_path calls will prefer custom
+# locations over standard locations (HINTS).  If the requested file is not found
+# at the HINTS location, standard system locations will be still be searched
+# (/usr/lib64 (Redhat), lib/i386-linux-gnu (Debian)).
 
+find_path( GSL_INCLUDE_DIR
+  NAMES gsl/gsl_sf.h
+  HINTS ${GSL_ROOT_DIR}/include ${GSL_INCLUDEDIR}
+)
+find_library( GSL_LIBRARY
+  NAMES gsl
+  HINTS ${GSL_ROOT_DIR}/lib ${GSL_LIBDIR}
+  PATH_SUFFIXES Release Debug
+)
+find_library( GSL_CBLAS_LIBRARY
+  NAMES gslcblas cblas
+  HINTS ${GSL_ROOT_DIR}/lib ${GSL_LIBDIR}
+  PATH_SUFFIXES Release Debug
+)
+# Do we also have debug versions?
+find_library( GSL_LIBRARY_DEBUG
+  NAMES gsld gsl
+  HINTS ${GSL_ROOT_DIR}/lib ${GSL_LIBDIR}
+  PATH_SUFFIXES Debug
+)
+find_library( GSL_CBLAS_LIBRARY_DEBUG
+  NAMES gslcblasd cblasd gslcblas cblas
+  HINTS ${GSL_ROOT_DIR}/lib ${GSL_LIBDIR}
+  PATH_SUFFIXES Debug
+)
+set( GSL_INCLUDE_DIRS ${GSL_INCLUDE_DIR} )
+set( GSL_LIBRARIES ${GSL_LIBRARY} ${GSL_CBLAS_LIBRARY} )
 
-  set(GSL_LIBRARIES ${GSL_LIBRARY} ${GSL_CBLAS_LIBRARY})
-  set(GSL_INCLUDE_DIRS ${GSL_INCLUDE_DIR})
+# If we didn't use PkgConfig, try to find the version via gsl-config or by
+# reading gsl_version.h.
+if( NOT GSL_VERSION )
+  # 1. If gsl-config exists, query for the version.
+  find_program( GSL_CONFIG_EXECUTABLE
+    NAMES gsl-config
+    HINTS "${GSL_ROOT_DIR}/bin"
+    )
+  if( EXISTS "${GSL_CONFIG_EXECUTABLE}" )
+    execute_process(
+      COMMAND "${GSL_CONFIG_EXECUTABLE}" --version
+      OUTPUT_VARIABLE GSL_VERSION
+      OUTPUT_STRIP_TRAILING_WHITESPACE )
+  endif()
 
-# handle the QUIETLY and REQUIRED arguments and set CCFITS_FOUND to TRUE if
-# all listed variables are TRUE
-  INCLUDE(FindPackageHandleStandardArgs)
-  FIND_PACKAGE_HANDLE_STANDARD_ARGS(GSL DEFAULT_MSG GSL_INCLUDE_DIRS GSL_LIBRARIES)
+  # 2. If gsl-config is not available, try looking in gsl/gsl_version.h
+  if( NOT GSL_VERSION AND EXISTS "${GSL_INCLUDE_DIRS}/gsl/gsl_version.h" )
+    file( STRINGS "${GSL_INCLUDE_DIRS}/gsl/gsl_version.h" gsl_version_h_contents REGEX "define GSL_VERSION" )
+    string( REGEX REPLACE ".*([0-9]\\.[0-9][0-9]?).*" "\\1" GSL_VERSION ${gsl_version_h_contents} )
+  endif()
 
-  mark_as_advanced(GSL_FOUND GSL_INCLUDE_DIRS GSL_LIBRARIES)
+  # might also try scraping the directory name for a regex match "gsl-X.X"
+endif()
 
-  list(REMOVE_DUPLICATES GSL_LIBRARIES)
-  list(REMOVE_DUPLICATES GSL_INCLUDE_DIRS)
+#=============================================================================
+# handle the QUIETLY and REQUIRED arguments and set GSL_FOUND to TRUE if all
+# listed variables are TRUE
+find_package_handle_standard_args( GSL
+  FOUND_VAR
+    GSL_FOUND
+  REQUIRED_VARS
+    GSL_INCLUDE_DIR
+    GSL_LIBRARY
+    GSL_CBLAS_LIBRARY
+  VERSION_VAR
+    GSL_VERSION
+    )
 
+mark_as_advanced( GSL_ROOT_DIR GSL_VERSION GSL_LIBRARY GSL_INCLUDE_DIR
+  GSL_CBLAS_LIBRARY GSL_LIBRARY_DEBUG GSL_CBLAS_LIBRARY_DEBUG
+  GSL_USE_PKGCONFIG GSL_CONFIG )
+
+#=============================================================================
+# Register imported libraries:
+# 1. If we can find a Windows .dll file (or if we can find both Debug and
+#    Release libraries), we will set appropriate target properties for these.
+# 2. However, for most systems, we will only register the import location and
+#    include directory.
+
+# Look for dlls, or Release and Debug libraries.
+if(WIN32)
+  string( REPLACE ".lib" ".dll" GSL_LIBRARY_DLL       "${GSL_LIBRARY}" )
+  string( REPLACE ".lib" ".dll" GSL_CBLAS_LIBRARY_DLL "${GSL_CBLAS_LIBRARY}" )
+  string( REPLACE ".lib" ".dll" GSL_LIBRARY_DEBUG_DLL "${GSL_LIBRARY_DEBUG}" )
+  string( REPLACE ".lib" ".dll" GSL_CBLAS_LIBRARY_DEBUG_DLL "${GSL_CBLAS_LIBRARY_DEBUG}" )
+endif()
+
+if( GSL_FOUND AND NOT TARGET GSL::gsl )
+  if( EXISTS "${GSL_LIBRARY_DLL}" AND EXISTS "${GSL_CBLAS_LIBRARY_DLL}")
+
+    # Windows systems with dll libraries.
+    add_library( GSL::gsl      SHARED IMPORTED )
+    add_library( GSL::gslcblas SHARED IMPORTED )
+
+    # Windows with dlls, but only Release libraries.
+    set_target_properties( GSL::gslcblas PROPERTIES
+      IMPORTED_LOCATION_RELEASE         "${GSL_CBLAS_LIBRARY_DLL}"
+      IMPORTED_IMPLIB                   "${GSL_CBLAS_LIBRARY}"
+      INTERFACE_INCLUDE_DIRECTORIES     "${GSL_INCLUDE_DIRS}"
+      IMPORTED_CONFIGURATIONS           Release
+      IMPORTED_LINK_INTERFACE_LANGUAGES "C" )
+    set_target_properties( GSL::gsl PROPERTIES
+      IMPORTED_LOCATION_RELEASE         "${GSL_LIBRARY_DLL}"
+      IMPORTED_IMPLIB                   "${GSL_LIBRARY}"
+      INTERFACE_INCLUDE_DIRECTORIES     "${GSL_INCLUDE_DIRS}"
+      IMPORTED_CONFIGURATIONS           Release
+      IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+      INTERFACE_LINK_LIBRARIES          GSL::gslcblas )
+
+    # If we have both Debug and Release libraries
+    if( EXISTS "${GSL_LIBRARY_DEBUG_DLL}" AND EXISTS "${GSL_CBLAS_LIBRARY_DEBUG_DLL}")
+      set_property( TARGET GSL::gslcblas APPEND PROPERTY IMPORTED_CONFIGURATIONS Debug )
+      set_target_properties( GSL::gslcblas PROPERTIES
+        IMPORTED_LOCATION_DEBUG           "${GSL_CBLAS_LIBRARY_DEBUG_DLL}"
+        IMPORTED_IMPLIB_DEBUG             "${GSL_CBLAS_LIBRARY_DEBUG}" )
+      set_property( TARGET GSL::gsl APPEND PROPERTY IMPORTED_CONFIGURATIONS Debug )
+      set_target_properties( GSL::gsl PROPERTIES
+        IMPORTED_LOCATION_DEBUG           "${GSL_LIBRARY_DEBUG_DLL}"
+        IMPORTED_IMPLIB_DEBUG             "${GSL_LIBRARY_DEBUG}" )
+    endif()
+
+  else()
+
+    # For all other environments (ones without dll libraries), create
+    # the imported library targets.
+    add_library( GSL::gsl      UNKNOWN IMPORTED )
+    add_library( GSL::gslcblas UNKNOWN IMPORTED )
+    set_target_properties( GSL::gslcblas PROPERTIES
+      IMPORTED_LOCATION                 "${GSL_CBLAS_LIBRARY}"
+      INTERFACE_INCLUDE_DIRECTORIES     "${GSL_INCLUDE_DIRS}"
+      IMPORTED_LINK_INTERFACE_LANGUAGES "C" )
+    set_target_properties( GSL::gsl PROPERTIES
+      IMPORTED_LOCATION                 "${GSL_LIBRARY}"
+      INTERFACE_INCLUDE_DIRECTORIES     "${GSL_INCLUDE_DIRS}"
+      IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+      INTERFACE_LINK_LIBRARIES          GSL::gslcblas )
+  endif()
 endif()


### PR DESCRIPTION
`GSL_ROOT_DIR` is used by the code from CMake as well, so the location can be overridden.

The main advantage from this code is that we can ask for a specific version when looking for GSL.