### PR TITLE
Change default of orig to None

### DIFF
--- a/ElementsKernel/python/ElementsKernel/Temporary.py
+++ b/ElementsKernel/python/ElementsKernel/Temporary.py
@@ -166,11 +166,13 @@ class Environment(object):
     Class to changes the environment temporarily.
     """
 
-    def __init__(self, orig=os.environ, keep_same=False):  # pylint: disable=dangerous-default-value
+    def __init__(self, orig=None, keep_same=False):
         """
         Create a temporary environment on top of the one specified
         (it can be another TemporaryEnvironment instance).
         """
+        if orig is None:
+            orig = os.environ
         self.old_values = {}
         self._orig = orig
         self.env = None


### PR DESCRIPTION
Pick os.environ inside. This makes pylint happy, and also fixes the
problem with the build of the rpms:

sphinx would "expand" into the documentation whatever there is on
the environment at build time, which breaks checks done by rpmbuild,
since the build path will appear inside a packaged file.