### PR TITLE
Fix compilation on macos

### DIFF
--- a/ElementsKernel/ElementsKernel/System.h
+++ b/ElementsKernel/ElementsKernel/System.h
@@ -89,15 +89,7 @@ const std::string SHLIB_SUFFIX{LIB_SUFFIX};
  */
 const std::string DEFAULT_INSTALL_PREFIX{"/usr"};
 
-#if defined(__OPTIMIZE__) && defined(__clang__)
-const int STACK_OFFSET{1};
-#else
-#ifdef __APPLE__
-const int         STACK_OFFSET{4};
-#else
 const int STACK_OFFSET{2};
-#endif
-#endif
 
 #if defined(__linux__) || defined(__APPLE__)
 #define TEMPLATE_SPECIALIZATION

--- a/ElementsKernel/src/Lib/ModuleInfo.cpp
+++ b/ElementsKernel/src/Lib/ModuleInfo.cpp
@@ -238,7 +238,6 @@ vector<Path::Item> linkedModulePaths() {
   Path::Item    self_maps = getSelfProc() / "maps";
   std::ifstream maps_str(self_maps.string());
 
-  string line;
   while (std::getline(maps_str, line)) {
     string             address, perms, offset, dev, pathname;
     unsigned           inode;

--- a/ElementsKernel/src/Lib/ModuleInfo.cpp
+++ b/ElementsKernel/src/Lib/ModuleInfo.cpp
@@ -242,11 +242,10 @@ const vector<string> linkedModules() {
 Path::Item getExecutablePath() {
 
 #ifdef __APPLE__
-  path         self_proc{};
   char         pathbuf[PATH_MAX + 1];
   unsigned int bufsize = sizeof(pathbuf);
   _NSGetExecutablePath(pathbuf, &bufsize);
-  path self_exe = path(string(pathbuf));
+  Path::Item self_exe = Path::Item(string(pathbuf));
 #else
 
   Path::Item self_exe = getSelfProc() / "exe";

--- a/ElementsKernel/src/Lib/System.cpp
+++ b/ElementsKernel/src/Lib/System.cpp
@@ -25,6 +25,7 @@
 #include <sys/utsname.h>
 #include <unistd.h>  // for environ
 
+#include <array>    // for array
 #include <cstdlib>  // for free, getenv, malloc, etc
 #include <iomanip>
 #include <iostream>

--- a/ElementsKernel/src/Lib/System.cpp
+++ b/ElementsKernel/src/Lib/System.cpp
@@ -385,6 +385,7 @@ int unSetEnv(const string& name) {
 // backtrace utilities
 // -----------------------------------------------------------------------------
 
+__attribute__((noinline))
 int backTrace(ELEMENTS_UNUSED std::shared_ptr<void*> addresses, ELEMENTS_UNUSED const int depth) {
 
   int count = ::backtrace(addresses.get(), depth);

--- a/ElementsKernel/tests/src/ModuleInfo_test.cpp
+++ b/ElementsKernel/tests/src/ModuleInfo_test.cpp
@@ -74,12 +74,14 @@ BOOST_AUTO_TEST_CASE(libraryName_test) {
   BOOST_CHECK_EQUAL(::basename(const_cast<char*>(info.libraryName().c_str())), "ModuleInfo_test");
 }
 
+#ifndef __APPLE__
 BOOST_AUTO_TEST_CASE(addresse_test) {
 
   const System::ModuleInfo& info = System::getThisModuleInfo();
 
   BOOST_CHECK_EQUAL(info.addresse(), static_cast<void*>(0));
 }
+#endif
 
 BOOST_AUTO_TEST_CASE(moduleName_test) {
 


### PR DESCRIPTION
I have had to patch 5.12 for releasing Elements on conda for macos. It is a trivial fix.

Also, there are some tests failing that I do not know how to fix:

* ModuleInfo_test/addresse_test
* ModuleInfo_test/linkedModules_test
* ModuleInfo_test/linkedModulePaths_test
* BackTrace_test/Raw_test

The last I know is because the `STACK_OFFSET` is probably wrong for the combination of compiler/platform, so the first call on the backtrace is `Elements::System::backTrace`. I do not know if the values are documented somewhere, and what the check should be (compiler version?)

The first one, I do not understand why the pointer is expected to be 0.

The second and third, they are based on `/proc` which does not exist in macos. I guess we'd need to look for an alternative.

I am happy to try fixing them, but I'd like to discuss them first.