### PR TITLE
Fix build of Logging.cpp in centos7

### DIFF
--- a/ElementsKernel/src/Lib/Logging.cpp
+++ b/ElementsKernel/src/Lib/Logging.cpp
@@ -55,7 +55,7 @@ static const std::map<string, const int> LOG_LEVEL{{"FATAL", Priority::FATAL},
 unique_ptr<Layout> getLogLayout() {
   auto layout = make_unique<log4cpp::PatternLayout>();
   layout->setConversionPattern("%d{%FT%T%Z} %c %5p : %m%n");
-  return layout;
+  return std::move(layout);
 }
 
 Logging::Logging(Category& log4cppLogger) : m_log4cppLogger(log4cppLogger) {}


### PR DESCRIPTION
As-is, this line fails in centos7. The compiler complains that `unique_ptr<PatternLayout>` can not be converted to `unique_ptr<Layout>`.

A compiler quirk, I guess.