### PR TITLE
Fix undefined behaviour

### DIFF
--- a/ElementsKernel/ElementsKernel/Real.h
+++ b/ElementsKernel/ElementsKernel/Real.h
@@ -73,6 +73,7 @@
 #define ELEMENTSKERNEL_ELEMENTSKERNEL_REAL_H_
 
 #include <cmath>        // for round
+#include <cstring>      // for memcpy
 #include <limits>       // for numeric_limits
 #include <type_traits>  // for is_floating_point
 
@@ -333,7 +334,8 @@ template <typename RawType>
 bool isNan(const RawType& x) {
 
   using Bits  = typename TypeWithSize<sizeof(RawType)>::UInt;
-  Bits x_bits = *reinterpret_cast<const Bits*>(&x);
+  Bits x_bits;
+  std::memcpy(&x_bits, &x, sizeof(x_bits));
 
   Bits x_exp_bits  = FloatingPoint<RawType>::s_exponent_bitmask & x_bits;
   Bits x_frac_bits = FloatingPoint<RawType>::s_fraction_bitmask & x_bits;
@@ -347,10 +349,11 @@ bool isEqual(const RawType& left, const RawType& right) {
   bool is_equal{false};
 
   if (not(isNan<RawType>(left) or isNan<RawType>(right))) {
-    using Bits  = typename TypeWithSize<sizeof(RawType)>::UInt;
-    Bits l_bits = *reinterpret_cast<const Bits*>(&left);
-    Bits r_bits = *reinterpret_cast<const Bits*>(&right);
-    is_equal    = (FloatingPoint<RawType>::distanceBetweenSignAndMagnitudeNumbers(l_bits, r_bits) <= max_ulps);
+    using Bits = typename TypeWithSize<sizeof(RawType)>::UInt;
+    Bits l_bits, r_bits;
+    std::memcpy(&l_bits, &left, sizeof(l_bits));
+    std::memcpy(&r_bits, &right, sizeof(r_bits));
+    is_equal = (FloatingPoint<RawType>::distanceBetweenSignAndMagnitudeNumbers(l_bits, r_bits) <= max_ulps);
   }
 
   return is_equal;

--- a/ElementsKernel/src/Lib/Real.cpp
+++ b/ElementsKernel/src/Lib/Real.cpp
@@ -42,14 +42,16 @@ bool almostEqual2sComplement(const float& left, const float& right, const int& m
   using std::uint32_t;
 
   // int a_int = *(int*)&a;
-  int32_t a_int = *reinterpret_cast<const int32_t*>(&left);
+  int32_t a_int;
+  std::memcpy(&a_int, &left, sizeof(int32_t));
   // Make a_int lexicographically ordered as a twos-complement int
   if (a_int < 0) {
     a_int = static_cast<int32_t>(0x80000000 - static_cast<uint32_t>(a_int));
   }
   // Make b_int lexicographically ordered as a twos-complement int
   //    int b_int = *(int*)&b;
-  int32_t b_int = *reinterpret_cast<const int32_t*>(&right);
+  int32_t b_int;
+  std::memcpy(&b_int, &right, sizeof(int32_t));
   if (b_int < 0) {
     b_int = static_cast<int32_t>(0x80000000 - static_cast<uint32_t>(b_int));
   }
@@ -67,14 +69,16 @@ bool almostEqual2sComplement(const double& left, const double& right, const int&
 
   // long long a_int = *(long long*)&a;
 
-  int64_t a_int = *reinterpret_cast<const int64_t*>(&left);
+  int64_t a_int;
+  std::memcpy(&a_int, &left, sizeof(a_int));
   // Make a_int lexicographically ordered as a twos-complement int
   if (a_int < 0) {
     a_int = static_cast<int64_t>(0x8000000000000000LL - static_cast<uint64_t>(a_int));
   }
   // Make b_int lexicographically ordered as a twos-complement int
   //    long long b_int = *(long long*)&b;
-  int64_t b_int = *reinterpret_cast<const int64_t*>(&right);
+  int64_t b_int;
+  std::memcpy(&b_int, &right, sizeof(b_int));
   if (b_int < 0) {
     b_int = static_cast<int64_t>(0x8000000000000000LL - static_cast<uint64_t>(b_int));
   }


### PR DESCRIPTION
Caused by reinterpret_cast. Since gcc 11, when compiling with `-O2 -flto`, the parameters passed to `isEqual` may end being uninitialized.

I don't know exactly why, though. My guess is that is has something to do with aliasing rules, so the compiler "thinks" that `a` and `b` are not used anyways (because two pointers to two different types are assumed to not be the same) so it may as well not bother giving them a value.